### PR TITLE
underscore supports hyphens

### DIFF
--- a/lib/atomic_map.ex
+++ b/lib/atomic_map.ex
@@ -50,9 +50,7 @@ defmodule AtomicMap do
 
   defp do_undescore(s) do
     s
-    |> String.replace(~r/([A-Z]+)([A-Z][a-z])/, "\\1_\\2")
-    |> String.replace(~r/([a-z\d])([A-Z])/, "\\1_\\2")
+    |> Macro.underscore
     |> String.replace(~r/-/, "_")
-    |> String.downcase
   end
 end

--- a/test/atomic_map_test.exs
+++ b/test/atomic_map_test.exs
@@ -66,6 +66,12 @@ defmodule AtomicMapTest do
     assert AtomicMap.convert(input, safe: false) == expected
   end
 
+  test "underscore flag works with hyphens" do
+    input    = %{ "first-key"  => {1,2}}
+    expected = %{first_key: {1, 2}}
+    assert AtomicMap.convert(input, safe: false) == expected
+  end
+
   test "raises for not existing atoms" do
     assert_raise ArgumentError, fn ->
       input = %{"a" => 2, "b" => %{"c" => 4}, "__not___existing__" => 5}


### PR DESCRIPTION
problem: 
- for some special use cases we want to convert hyphens to underscores while underscoring

solution: 
- combine Macro.underscore + replace "-" with "_" 
- unit test to cover this
