### PR TITLE
adds a benchfella benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ iex> AtomicMap.convert(%{ "CamelCase" => [ %{"c" => 1}, %{"c" => 2}] }, safe: fa
 # underscoring can be turned off by passing `underscore: false` to opts
 iex> AtomicMap.convert(%{ "CamelCase" => [ %{"c" => 1}, %{"c" => 2}] }, safe: false, underscore: false )
 %{CamelCase: [%{c: 1}, %{c: 2}]}
+
+# hyphens are replaced
+iex> AtomicMap.convert(%{ "some-key" => [ %{"c" => 1}, %{"c" => 2}] }, safe: false, underscore: true )
+%{some_key: [%{c: 1}, %{c: 2}]}
 ```
 
 
@@ -38,3 +42,8 @@ iex> AtomicMap.convert(%{ "CamelCase" => [ %{"c" => 1}, %{"c" => 2}] }, safe: fa
 
 ## Todo:
   - maybe allow direct conversion to a struct, like Poison does it: as: %SomeStruct{}...
+
+
+## Benchmark
+
+    $ mix bench

--- a/bench/basic_bench.exs
+++ b/bench/basic_bench.exs
@@ -1,0 +1,36 @@
+defmodule BasicBench do
+  use Benchfella
+
+  def macro_underscore(s) do
+    s
+    |> Macro.underscore
+    |> String.replace(~r/-/, "_")
+  end
+
+  def regex_underscore(s) do
+    s
+    |> String.replace(~r/([A-Z]+)([A-Z][a-z])/, "\\1_\\2")
+    |> String.replace(~r/([a-z\d])([A-Z])/, "\\1_\\2")
+    |> String.replace(~r/-/, "_")
+    |> String.downcase
+  end
+
+  @long_string "StringShouldChange-some_stuffStringShouldChange-some_stuffStringShouldChange-some_stuffStringShouldChange-some_stuffStringShouldChange-some_stuff"
+  @short_string "StringShouldChange-some_stuff"
+
+  bench "macro_underscore - long" do
+    @long_string |> macro_underscore
+  end
+
+  bench "regex_underscore - long" do
+    @long_string |> regex_underscore
+  end
+
+  bench "macro_underscore - short" do
+    @short_string |> macro_underscore
+  end
+
+  bench "regex_underscore - short" do
+    @short_string |> regex_underscore
+  end
+end

--- a/bench/snapshots/2016-05-04_22-21-57.snapshot
+++ b/bench/snapshots/2016-05-04_22-21-57.snapshot
@@ -1,0 +1,6 @@
+duration:1.0;mem stats:false;sys mem stats:false
+module;test;tags;iterations;elapsed
+BasicBench	regex_underscore - short		100000	2667305
+BasicBench	regex_underscore - long		20000	1656602
+BasicBench	macro_underscore - short		100000	1347365
+BasicBench	macro_underscore - long		50000	2556233

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,8 @@ defmodule AtomicMap.Mixfile do
   defp deps do
     [
       {:earmark, "~> 0.2", only: :dev},
-      {:ex_doc, "~> 0.11", only: :dev}
+      {:ex_doc, "~> 0.11", only: :dev},
+      {:benchfella, "0.3.2", only: :dev},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
+%{"benchfella": {:hex, :benchfella, "0.3.2"},
+  "earmark": {:hex, :earmark, "0.2.1"},
   "ex_doc": {:hex, :ex_doc, "0.11.4"}}


### PR DESCRIPTION
problem:
- in PR https://github.com/ruby2elixir/atomic_map/pull/5 I wanted to compare different implementations for underscoring

solution: 
- use benchfella package 
- small script

results: 
- the Macro.underscore version is roughly 2x faster... that time adds up on larger json payloads, so I'll keep it for now. It's always possible to switch it to something custom later, if that becomes a problem. 

```
## BasicBench
macro_underscore - short      100000   11.23 µs/op
regex_underscore - short      100000   26.51 µs/op
macro_underscore - long        50000   45.81 µs/op
regex_underscore - long        20000   75.77 µs/op
```
