### PR TITLE
Ignore unsafe string-to-atoms

### DIFF
--- a/lib/atomic_map.ex
+++ b/lib/atomic_map.ex
@@ -11,7 +11,7 @@ defmodule AtomicMap do
 
   def convert(struct=%{__struct__: type}, opts=%AtomicMap.Opts{}) do
     struct
-    |> Map.from_struct
+    |> Map.from_struct()
     |> convert(opts)
     |> Map.put(:__struct__, type)
   end
@@ -26,7 +26,7 @@ defmodule AtomicMap do
     list |> Enum.map(fn(x)-> convert(x, opts) end)
   end
   def convert(tuple, opts=%AtomicMap.Opts{}) when is_tuple(tuple) do
-    tuple |> Tuple.to_list |> convert(opts) |> List.to_tuple
+    tuple |> Tuple.to_list |> convert(opts) |> List.to_tuple()
   end
   def convert(v, _opts=%AtomicMap.Opts{}),  do: v
 
@@ -40,17 +40,23 @@ defmodule AtomicMap do
     |> as_atom(opts.safe)
   end
 
-  defp as_atom(s, true)  when is_binary(s),  do: s |> String.to_existing_atom
-  defp as_atom(s, false) when is_binary(s),  do: s |> String.to_atom
+  defp as_atom(s, true)  when is_binary(s) do
+    try do
+      s |> String.to_existing_atom()
+    rescue
+      ArgumentError -> s
+    end
+  end
+  defp as_atom(s, false) when is_binary(s),  do: s |> String.to_atom()
   defp as_atom(s, _),                        do: s
 
-  defp as_underscore(s, true)  when is_binary(s), do: s |> do_undescore
-  defp as_underscore(s, true)  when is_atom(s),   do: s |> Atom.to_string |> as_underscore(true)
+  defp as_underscore(s, true)  when is_binary(s), do: s |> do_underscore()
+  defp as_underscore(s, true)  when is_atom(s),   do: s |> Atom.to_string() |> as_underscore(true)
   defp as_underscore(s, false),                   do: s
 
-  defp do_undescore(s) do
+  defp do_underscore(s) do
     s
-    |> Macro.underscore
+    |> Macro.underscore()
     |> String.replace(~r/-/, "_")
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule AtomicMap.Mixfile do
   def project do
     [app: :atomic_map,
      version: @version,
-     elixir: "~> 1.2",
+     elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package(),
@@ -31,9 +31,9 @@ defmodule AtomicMap.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:earmark, "~> 0.2", only: :dev},
-      {:ex_doc, "~> 0.11", only: :dev},
-      {:benchfella, "0.3.2", only: :dev},
+      {:earmark, "~> 1.1", only: :dev},
+      {:ex_doc, "~> 0.14", only: :dev},
+      {:benchfella, "~> 0.3", only: :dev},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"benchfella": {:hex, :benchfella, "0.3.2", "b9648e77fa8d8b8b9fe8f54293bee63f7de03909b3af6ab22a0e546716a396fb", [:mix], []},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}
+  "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}

--- a/test/atomic_map_test.exs
+++ b/test/atomic_map_test.exs
@@ -60,7 +60,7 @@ defmodule AtomicMapTest do
     assert AtomicMap.convert(input) == expected
   end
 
-  test "convertes keys to underscore by default (attention: safe: false needed here)" do
+  test "converts keys to underscore by default (attention: safe: false needed here)" do
     input    = %{ "firstKey"  => {1,2}, :secondKey => 4}
     expected = %{first_key: {1, 2}, second_key: 4}
     assert AtomicMap.convert(input, safe: false) == expected
@@ -72,10 +72,9 @@ defmodule AtomicMapTest do
     assert AtomicMap.convert(input, safe: false) == expected
   end
 
-  test "raises for not existing atoms" do
-    assert_raise ArgumentError, fn ->
-      input = %{"a" => 2, "b" => %{"c" => 4}, "__not___existing__" => 5}
-      AtomicMap.convert(input, safe: true)
-    end
+  test "skips not existing atoms" do
+    input    = %{"unknow_val" => 2}
+    expected = %{"unknow_val" => 2}
+    assert AtomicMap.convert(input, %{safe: true}) == expected
   end
 end


### PR DESCRIPTION
It's open to discussion, whether you want unknown atoms to be ignored, or errors raised.
I chose to ignore them. Maybe create some kind of option, to be able to choose the behaviour of the converter.